### PR TITLE
Add support for excluding models from search index using $excludeFromSearchIndex [sc-120865]

### DIFF
--- a/src/Searchable/SearchableListFactory.php
+++ b/src/Searchable/SearchableListFactory.php
@@ -143,6 +143,14 @@ final class SearchableListFactory
         try {
             $reflection = $this->reflector()->reflectClass($class);
 
+            if ($reflection->hasProperty('excludeFromSearchIndex')) {
+                $property = $reflection->getProperty('excludeFromSearchIndex');
+
+                if ($property->getDefaultValue() === true) {
+                    return false;
+                }
+            }
+
             if (in_array(Searchable::class, $traits = $reflection->getTraitNames())) {
                 return true;
             }


### PR DESCRIPTION
# Add support for excluding models from search index using $excludeFromSearchIndex

## Summary
Adds the ability to explicitly exclude a model from being discovered as searchable by setting an `$excludeFromSearchIndex` property to `true`.

## Motivation
Previously, any model using the `Searchable` trait would be included in the search index. There was no way to opt out of indexing at the class level without removing the trait entirely — which may not always be desirable if the trait is inherited or pulled in transitively.

## Changes
- In `findSearchableTraitRecursively()`, before checking for the `Searchable` trait, the method now inspects the class for an `$excludeFromSearchIndex` property. If the property exists and its default value is `true`, the class is treated as non-searchable and excluded from the index.

## Usage
```php
class MyModel extends Model
{
    use Searchable;

    protected bool $excludeFromSearchIndex = true;
}
```

## Notes
- The check uses `getDefaultValue()`, so only the declared default matters — runtime assignment has no effect on discovery.
- This is a non-breaking change; existing models with no such property are unaffected.