### PR TITLE
Improve reindex output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ composer.lock
 .env
 .phpunit.result.cache
 /vendor/
+.DS_Store
+.php-cs-fixer.cache
+.php_cs.cache
+/build/
+coverage/
+coverage.xml
+clover.xml

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,19 @@
             "Matchish\\ScoutElasticSearch\\": "src/"
         }
     },
+    "scripts": {
+        "test": "phpunit",
+        "analyse": "phpstan analyse",
+        "quality": [
+            "@composer validate --strict",
+            "@test"
+        ]
+    },
+    "scripts-descriptions": {
+        "test": "Run the PHPUnit test suite",
+        "analyse": "Run PHPStan (Larastan) static analysis at level max (not yet in the quality gate: baseline still has pre-existing errors)",
+        "quality": "Run all quality checks before committing: composer validate and tests"
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/resources/lang/en/import.php
+++ b/resources/lang/en/import.php
@@ -4,4 +4,12 @@ return [
     'start' => 'Importing [:searchable]',
     'done' => 'All [:searchable] records have been imported.',
     'done.queue' => 'Import job dispatched to the queue.',
+    'summary' => 'Reindex summary for [:searchable]',
+    'summary.previous' => 'Documents in previous index',
+    'summary.expected' => 'Eligible records in database',
+    'summary.indexed' => 'Documents in new index',
+    'summary.difference' => 'Difference vs previous index',
+    'summary.duration' => 'Duration',
+    'summary.none' => 'none (new index)',
+    'mismatch' => 'Indexed :indexed of :expected eligible records (:missing fewer). This can be expected when shouldBeSearchable() filters records out; otherwise a chunk may have failed to index — re-run the import to confirm.',
 ];

--- a/src/Console/Commands/ImportCommand.php
+++ b/src/Console/Commands/ImportCommand.php
@@ -12,6 +12,8 @@ use Matchish\ScoutElasticSearch\Jobs\QueueableJob;
 use Matchish\ScoutElasticSearch\Searchable\ImportSource;
 use Matchish\ScoutElasticSearch\Searchable\ImportSourceFactory;
 use Matchish\ScoutElasticSearch\Searchable\SearchableListFactory;
+use OpenSearch\Client;
+use OpenSearch\Common\Exceptions\Missing404Exception;
 
 final class ImportCommand extends Command
 {
@@ -51,7 +53,9 @@ final class ImportCommand extends Command
         $job = new Import($source);
         $job->timeout = Config::queueTimeout();
 
-        if (config('scout.queue')) {
+        $queued = (bool) config('scout.queue');
+
+        if ($queued) {
             $job = (new QueueableJob())->chain([$job]);
             $job->timeout = Config::queueTimeout();
         }
@@ -62,13 +66,85 @@ final class ImportCommand extends Command
         $startMessage = trans('scout::import.start', ['searchable' => "<comment>$searchable</comment>"]);
         $this->line($startMessage);
 
+        // Snapshot the state before the import so we can report what changed.
+        // Only meaningful for synchronous imports; when queued the work runs
+        // elsewhere and the alias still points at the previous index here.
+        $elasticsearch = app(Client::class);
+        $previousCount = $queued ? null : $this->documentCount($elasticsearch, $source->searchableAs());
+        $expectedCount = $queued ? null : $source->count();
+        $startedAt = microtime(true);
+
         /* @var ImportSource $source */
         dispatch($job)->allOnQueue($source->syncWithSearchUsingQueue())
             ->allOnConnection($source->syncWithSearchUsing());
 
-        $doneMessage = trans(config('scout.queue') ? 'scout::import.done.queue' : 'scout::import.done', [
+        if (! $queued) {
+            $newCount = $this->documentCount($elasticsearch, $source->searchableAs());
+            $this->summary($searchable, $previousCount, $expectedCount, $newCount, microtime(true) - $startedAt);
+        }
+
+        $doneMessage = trans($queued ? 'scout::import.done.queue' : 'scout::import.done', [
             'searchable' => $searchable,
         ]);
         $this->output->success($doneMessage);
+    }
+
+    /**
+     * Number of documents currently reachable through the given index/alias,
+     * or null when it does not exist yet (first import).
+     */
+    private function documentCount(Client $elasticsearch, string $index): ?int
+    {
+        try {
+            return (int) $elasticsearch->count(['index' => $index])['count'];
+        } catch (Missing404Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Render a table comparing the previous index with the freshly built one.
+     */
+    private function summary(
+        string $searchable,
+        ?int $previousCount,
+        ?int $expectedCount,
+        ?int $newCount,
+        float $duration
+    ): void {
+        $this->newLine();
+        $this->line(trans('scout::import.summary', ['searchable' => "<comment>$searchable</comment>"]));
+        $this->table(['Metric', 'Value'], [
+            [trans('scout::import.summary.previous'), $this->formatCount($previousCount)],
+            [trans('scout::import.summary.expected'), $this->formatCount($expectedCount)],
+            [trans('scout::import.summary.indexed'), $this->formatCount($newCount)],
+            [trans('scout::import.summary.difference'), $this->formatDifference($previousCount, $newCount)],
+            [trans('scout::import.summary.duration'), sprintf('%.2fs', $duration)],
+        ]);
+
+        if ($expectedCount !== null && $newCount !== null && $newCount < $expectedCount) {
+            $this->warn(trans('scout::import.mismatch', [
+                'indexed' => number_format($newCount),
+                'expected' => number_format($expectedCount),
+                'missing' => number_format($expectedCount - $newCount),
+            ]));
+        }
+    }
+
+    private function formatCount(?int $count): string
+    {
+        return $count === null ? trans('scout::import.summary.none') : number_format($count);
+    }
+
+    private function formatDifference(?int $previousCount, ?int $newCount): string
+    {
+        if ($previousCount === null || $newCount === null) {
+            return 'n/a';
+        }
+
+        $difference = $newCount - $previousCount;
+        $sign = $difference > 0 ? '+' : ($difference < 0 ? '-' : '');
+
+        return $sign.number_format(abs($difference));
     }
 }

--- a/src/Searchable/DefaultImportSource.php
+++ b/src/Searchable/DefaultImportSource.php
@@ -47,10 +47,14 @@ final class DefaultImportSource implements ImportSource
         return $this->model()->searchableAs();
     }
 
+    public function count(): int
+    {
+        return $this->newQuery()->count();
+    }
+
     public function chunked(): Collection
     {
-        $query = $this->newQuery();
-        $totalSearchables = $query->count();
+        $totalSearchables = $this->count();
 
         if ($totalSearchables) {
             $chunkSize = (int) config('scout.chunk.searchable', self::DEFAULT_CHUNK_SIZE);

--- a/src/Searchable/ImportSource.php
+++ b/src/Searchable/ImportSource.php
@@ -16,4 +16,9 @@ interface ImportSource
     public function chunked(): Collection;
 
     public function get(): EloquentCollection;
+
+    /**
+     * Total number of records the source is expected to index.
+     */
+    public function count(): int;
 }

--- a/tests/Feature/ImportCommandTest.php
+++ b/tests/Feature/ImportCommandTest.php
@@ -53,6 +53,86 @@ final class ImportCommandTest extends IntegrationTestCase
     /**
      * @test
      */
+    public function reindex_summary_reports_document_counts(): void
+    {
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        $searchableAmount = 4;
+        factory(Product::class, $searchableAmount)->create();
+
+        $unsearchableAmount = 2;
+        factory(Product::class, $unsearchableAmount)->states(['archive'])->create();
+
+        Product::setEventDispatcher($dispatcher);
+
+        $output = new BufferedOutput();
+        Artisan::call('scout:import', ['searchable' => [Product::class]], $output);
+
+        $output = $output->fetch();
+
+        // Summary header and the metric labels are rendered.
+        $this->assertStringContainsString('Reindex summary', $output);
+        $this->assertStringContainsString(trans('scout::import.summary.previous'), $output);
+        $this->assertStringContainsString(trans('scout::import.summary.indexed'), $output);
+
+        // Previous index did not exist yet, so it reports as a new index.
+        $this->assertStringContainsString(trans('scout::import.summary.none'), $output);
+
+        // Only the searchable products end up in the new index. The archived
+        // ones are filtered by shouldBeSearchable(), so a mismatch note is shown.
+        $this->assertStringContainsString((string) $searchableAmount, $output);
+        $this->assertStringContainsString(
+            trans('scout::import.mismatch', [
+                'indexed' => number_format($searchableAmount),
+                'expected' => number_format($searchableAmount + $unsearchableAmount),
+                'missing' => number_format($unsearchableAmount),
+            ]),
+            $output
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function reindex_summary_reports_signed_difference_against_previous_index(): void
+    {
+        // Seed a previous index (aliased as "products") holding 2 documents.
+        $this->elasticsearch->indices()->create([
+            'index' => 'products_old',
+            'body' => [
+                'aliases' => ['products' => new stdClass()],
+                'settings' => ['number_of_shards' => 1, 'number_of_replicas' => 0],
+            ],
+        ]);
+        foreach ([1, 2] as $id) {
+            $this->elasticsearch->index([
+                'index' => 'products_old',
+                'id' => (string) $id,
+                'body' => ['type' => 'default'],
+            ]);
+        }
+        $this->elasticsearch->indices()->refresh(['index' => 'products_old']);
+
+        $dispatcher = Product::getEventDispatcher();
+        Product::unsetEventDispatcher();
+
+        // Import 5 searchable products, so the new index has +3 vs the previous.
+        factory(Product::class, 5)->create();
+        Product::setEventDispatcher($dispatcher);
+
+        $output = new BufferedOutput();
+        Artisan::call('scout:import', ['searchable' => [Product::class]], $output);
+
+        $output = $output->fetch();
+
+        $this->assertStringContainsString(trans('scout::import.summary.difference'), $output);
+        $this->assertStringContainsString('+3', $output);
+    }
+
+    /**
+     * @test
+     */
     public function import_entites_in_queue(): void
     {
         $this->app['config']->set('scout.queue', ['connection' => 'sync', 'queue' => 'scout']);
@@ -176,23 +256,12 @@ final class ImportCommandTest extends IntegrationTestCase
         $output = new BufferedOutput();
         Artisan::call('scout:import', ['searchable' => [Product::class, Book::class]], $output);
 
-        $output = explode("\n", $output->fetch());
-        $this->assertEquals(
-            trans('scout::import.start', ['searchable' => Product::class]),
-            trim($output[0])
-        );
-        $this->assertEquals(
-            '[OK] '.trans('scout::import.done', ['searchable' => Product::class]),
-            trim($output[17])
-        );
-        $this->assertEquals(
-            trans('scout::import.start', ['searchable' => Book::class]),
-            trim($output[19])
-        );
-        $this->assertEquals(
-            '[OK] '.trans('scout::import.done', ['searchable' => Book::class]),
-            trim($output[36])
-        );
+        $output = array_map('trim', explode("\n", $output->fetch()));
+
+        $this->assertContains(trans('scout::import.start', ['searchable' => Product::class]), $output);
+        $this->assertContains('[OK] '.trans('scout::import.done', ['searchable' => Product::class]), $output);
+        $this->assertContains(trans('scout::import.start', ['searchable' => Book::class]), $output);
+        $this->assertContains('[OK] '.trans('scout::import.done', ['searchable' => Book::class]), $output);
     }
 
     /**


### PR DESCRIPTION
## What & why

The `scout:import` (reindex) command previously ended with only an `[OK] All records have been imported` message. We hit cases where the new index ended up with **fewer documents than the old one**, and there was no way to see it from the command output — you had to query the cluster manually, and it often "fixed itself" after a few reindexes.

This adds a summary table at the end of each synchronous import so the outcome is visible at a glance.

## Output

```
Reindex summary for [App\User]
+------------------------------+-------+
| Metric                       | Value |
+------------------------------+-------+
| Documents in previous index  | 4,401 |
| Eligible records in database | 4,401 |
| Documents in new index       | 4,401 |
| Difference vs previous index | 0     |
| Duration                     | 6.33s |
+------------------------------+-------+
```

When the new index has fewer docs than the DB expected, a warning line explains the two likely causes (legit `shouldBeSearchable()` filtering vs. a chunk that failed to index — re-run to confirm), which directly addresses the intermittent under-count we were seeing.

## Metrics

- **Documents in previous index** — doc count of the live alias before the reindex (`none (new index)` on first import).
- **Eligible records in database** — rows the source query returns (`makeAllSearchableUsing`-aware); the expected upper bound.
- **Documents in new index** — ground-truth `_count` of the freshly built index after refresh.
- **Difference vs previous index** — signed delta (`+3`, `-500`, ...).
- **Duration** — wall-clock time.

## Changes

- `src/Console/Commands/ImportCommand.php` — snapshots counts before/after dispatch and renders the table. Skipped for queued imports (work runs elsewhere; keeps the existing "dispatched to queue" message).
- `src/Searchable/ImportSource.php` + `DefaultImportSource.php` — added a `count()` method for the expected total; `chunked()` reuses it. **Note:** this adds a method to the `ImportSource` interface — any custom implementation will need it too.
- `resources/lang/en/import.php` — all new strings are translatable.
- `.gitignore` — ignore `.DS_Store`, php-cs-fixer/Pint caches, and coverage/build output.
- `composer.json` — added `composer quality` (validate + tests), `composer test`, and `composer analyse` scripts.
- Tests — added summary-output coverage; made the `progress_report` test robust to output changes (it was asserting hard-coded line numbers).

## Follow-up

`composer analyse` (PHPStan level max) is wired but **not** in the `quality` gate yet — there are 111 pre-existing baseline errors. A separate PR will use `composer analyse` to fix those and then add `@analyse` to the gate.

## Testing

All 71 tests pass (`composer quality` is green).